### PR TITLE
Check for internal selfsigned ssl validation

### DIFF
--- a/bin/onlineTests.sh
+++ b/bin/onlineTests.sh
@@ -10,6 +10,8 @@ if pgrep -u lool loolwsd; then
   pkill -u lool loolwsd
   systemctl enable $loolwsd_service_name.service
   systemctl daemon-reload
+  echo -e "\033[33;7m### Don't forget to take a look at your SSL cert in a year (or less). ###\033[0m"
+  ssl-cert-check -c /etc/loolwsd/cert.pem
 else
   echo -e "\033[33;5m### loolwsd is not running. Something went wrong :| Please look in ${log_dir} or try to restart your system ###\033[0m"
 fi

--- a/bin/systemSetup.sh
+++ b/bin/systemSetup.sh
@@ -71,10 +71,10 @@ fi
 if ! apt-get install ant sudo systemd wget zip make procps automake bison ccache \
 flex g++ git gperf graphviz junit4 libcap-dev libcppunit-dev build-essential \
 libcppunit-doc libcunit1 libcunit1-dev libegl1-mesa-dev libfontconfig1-dev libgl1-mesa-dev \
-libgtk-3-dev libgtk2.0-dev libkrb5-dev libpcap0.8 libpcap0.8-dev libtool \
+libgtk-3-dev libgtk2.0-dev libkrb5-dev libpcap0.8 libpcap0.8-dev libtool libpam0g-dev \
 libxml2-utils libxrandr-dev libxrender-dev libxslt1-dev libxt-dev m4 nasm openssl libssl-dev \
 pkg-config python-dev python-polib python3-dev uuid-runtime xsltproc libcap2-bin python-lxml \
-  ${DIST_PKGS} -y; then
+ssl-cert-check ${DIST_PKGS} -y; then
     exit 1
 fi
 if ! ${lo_mini}; then


### PR DESCRIPTION
The internal self signed SSL cert for loolwsd will expire in 1 year. It doesn't gets recreated at (re)build time, so even when rebuilding each month it will break at 1 year of usage.

This step is only to make aware of that issue, maybe rebuilding a new cert/key at build if the cert is lower than a month, would be the next step.

Cheers!